### PR TITLE
Io/socket assign

### DIFF
--- a/include/nhope/io/tcp.h
+++ b/include/nhope/io/tcp.h
@@ -37,6 +37,7 @@ public:
 
     struct Options
     {
+        bool nonBlocking = true;
         std::optional<bool> keepAlive;
         std::optional<bool> reuseAddress;
         std::optional<int> receiveBufferSize;
@@ -53,6 +54,15 @@ public:
     virtual void shutdown(Shutdown = Shutdown::Both) = 0;
 
     static Future<TcpSocketPtr> connect(AOContext& aoCtx, std::string_view hostName, std::uint16_t port);
+
+    /*!
+     * @brief wraps already prepared socket
+     * 
+     * @param aoCtx ctx
+     * @param handle native
+     * @return TcpSocketPtr wrapped async socket
+     */
+    static TcpSocketPtr create(AOContext& aoCtx, NativeHandle handle);
 };
 
 class TcpServer;

--- a/include/nhope/io/udp.h
+++ b/include/nhope/io/udp.h
@@ -29,6 +29,7 @@ public:
     {
         Endpoint bindAddress;
         std::optional<Endpoint> peerAddress;
+        bool nonBlocking = true;
 
         std::optional<bool> broadcast;
         std::optional<bool> reuseAddress;
@@ -43,6 +44,8 @@ public:
     [[nodiscard]] virtual SockAddr peerAddress() const = 0;
 
     static UdpSocketPtr create(AOContext& aoCtx, const Params& params);
+    // wraps already prepared socket
+    static UdpSocketPtr create(AOContext& aoCtx, NativeHandle native);
 };
 
 }   // namespace nhope

--- a/lib/io/udp.cpp
+++ b/lib/io/udp.cpp
@@ -23,6 +23,13 @@ public:
         setOptions(params);
     }
 
+    explicit UdpSocketImpl(nhope::AOContext& parentAOCtx, NativeHandle handle)
+      : m_socket(parentAOCtx.executor().ioCtx())
+      , m_aoCtx(parentAOCtx)
+    {
+        m_socket.assign(asio::ip::udp::v4(), static_cast<int>(handle));
+    }
+
     ~UdpSocketImpl() override = default;
 
     [[nodiscard]] NativeHandle nativeHandle() override
@@ -102,6 +109,7 @@ private:
             const asio::socket_base::send_buffer_size option(opts.sendBufferSize.value());
             m_socket.set_option(option);
         }
+        m_socket.non_blocking(opts.nonBlocking);
     }
 
 private:
@@ -114,6 +122,11 @@ private:
 UdpSocketPtr UdpSocket::create(AOContext& aoCtx, const UdpSocketImpl::Params& params)
 {
     return std::make_unique<UdpSocketImpl>(aoCtx, params);
+}
+
+UdpSocketPtr UdpSocket::create(AOContext& aoCtx, NativeHandle native)
+{
+    return std::make_unique<UdpSocketImpl>(aoCtx, native);
 }
 
 }   // namespace nhope

--- a/tests/io/io-tests.cpp
+++ b/tests/io/io-tests.cpp
@@ -799,6 +799,28 @@ TEST(IOTest, tcpServerBindAddress)   // NOLINT
     EXPECT_EQ(port.value(), listenPort);   // NOLINT
 }
 
+TEST(IOTest, tcpSocketAssign)   // NOLINT
+{
+    test::TcpEchoServer echoServer;
+    ThreadExecutor e;
+    AOContext aoCtx(e);
+
+    // some legacy api socket
+    sockaddr_in servaddr;
+    const auto sockfd = socket(AF_INET, SOCK_STREAM, 0);
+    servaddr.sin_family = AF_INET;
+    servaddr.sin_addr.s_addr = htonl(0x7f000001);
+    servaddr.sin_port = htons(test::TcpEchoServer::srvPort);
+    connect(sockfd, (sockaddr*)&servaddr, sizeof(servaddr));
+
+    auto wrapper = TcpSocket::create(aoCtx, sockfd);
+    const std::vector<std::uint8_t> data{0, 1, 2, 3, 4, 5};
+    nhope::write(*wrapper, data).get();
+    auto readded = nhope::read(*wrapper, data.size()).get();
+    EXPECT_EQ(readded, data);
+    close(sockfd);
+}
+
 TEST(IOTest, hostNameResolveFailed)   // NOLINT
 {
     ThreadExecutor e;

--- a/tests/io/io-tests.cpp
+++ b/tests/io/io-tests.cpp
@@ -1353,3 +1353,34 @@ TEST(IOTest, udpSocketCancel)   //NOLINT
     socket->ioCancel();
     EXPECT_THROW(future.get(), std::system_error);   // NOLINT
 }
+
+TEST(IOTest, udpSocketAssign)   // NOLINT
+{
+    ThreadExecutor e;
+    AOContext aoCtx(e);
+    UdpSocket::Params p;
+    p.bindAddress.address = "0.0.0.0";
+    p.bindAddress.port = 0;
+
+    test::UdpEchoServer echoServer(p);
+    const auto port = echoServer.bindPort();
+    const auto sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+
+    // legacy udp socket
+    sockaddr_in servaddr{};
+    servaddr.sin_family = AF_INET;   // IPv4
+    servaddr.sin_addr.s_addr = INADDR_ANY;
+    servaddr.sin_port = htons(port);
+    const std::vector<std::uint8_t> etalon{1, 2, 3, 4, 5, 4, 3, 2, 1};
+    sendto(sockfd, etalon.data(), etalon.size(), MSG_CONFIRM, (const struct sockaddr*)&servaddr, sizeof(servaddr));
+
+    auto client = UdpSocket::create(aoCtx, sockfd);
+    auto receiveData = nhope::read(*client, etalon.size()).get();
+    EXPECT_EQ(receiveData, etalon);
+    nhope::write(*client, etalon).get();
+    std::vector<std::uint8_t> rx(etalon.size());
+    recv(sockfd, rx.data(), rx.size(), 0);
+    EXPECT_EQ(rx, etalon);
+
+    close(sockfd);
+}


### PR DESCRIPTION
Для сокетов добавлены методы назначения дескрипторов. Очень полезная штука, особенно когда работаешь со сторонней си-библиотекой.